### PR TITLE
Improvement: new method 'end_ext' for `FileWriter`

### DIFF
--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -20,7 +20,7 @@ pub(super) fn start_file<W: Write>(writer: &mut W) -> Result<u64> {
     Ok(PARQUET_MAGIC.len() as u64)
 }
 
-pub(super) fn end_file<W: Write>(mut writer: &mut W, metadata: FileMetaData) -> Result<u64> {
+pub(super) fn end_file<W: Write>(mut writer: &mut W, metadata: &FileMetaData) -> Result<u64> {
     // Write metadata
     let mut protocol = TCompactOutputProtocol::new(&mut writer);
     let metadata_len = metadata.write_to_out_protocol(&mut protocol)? as i32;
@@ -117,6 +117,16 @@ impl<W: Write> FileWriter<W> {
     /// Writes the footer of the parquet file. Returns the total size of the file and the
     /// underlying writer.
     pub fn end(mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<(u64, W)> {
+        let (len, writer, _) = self.end_ext(key_value_metadata)?;
+        Ok((len, writer))
+    }
+
+    /// Writes the footer of the parquet file. Returns the total size of the file and the
+    /// underlying writer.
+    pub fn end_ext(
+        mut self,
+        key_value_metadata: Option<Vec<KeyValue>>,
+    ) -> Result<(u64, W, FileMetaData)> {
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();
 
@@ -132,8 +142,8 @@ impl<W: Write> FileWriter<W> {
             None,
         );
 
-        let len = end_file(&mut self.writer, metadata)?;
-        Ok((self.offset + len, self.writer))
+        let len = end_file(&mut self.writer, &metadata)?;
+        Ok((self.offset + len, self.writer, metadata))
     }
 }
 
@@ -163,7 +173,7 @@ mod tests {
 
         // write the file
         start_file(&mut writer)?;
-        end_file(&mut writer, metadata.into_thrift()?)?;
+        end_file(&mut writer, &metadata.into_thrift()?)?;
 
         let a = writer.into_inner();
 


### PR DESCRIPTION
which returns FileMetaData as well, so that the caller site of the writer may access the FileMetaData without re-opening.